### PR TITLE
fix(deps): Revert main Azure App Registration and Enterprise Application Orchestrator extension .NET project to .NET 6 from .NET 8.

### DIFF
--- a/AzureEnterpriseApplicationOrchestrator/AzureEnterpriseApplicationOrchestrator.csproj
+++ b/AzureEnterpriseApplicationOrchestrator/AzureEnterpriseApplicationOrchestrator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
@@ -17,7 +17,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
-      <PackageReference Include="Keyfactor.Logging" Version="1.1.2" />
+      <PackageReference Include="Keyfactor.Logging" Version="1.1.1" />
       <PackageReference Include="Keyfactor.Orchestrators.IOrchestratorJobExtensions" Version="0.7.0" />
       <PackageReference Include="Microsoft.Graph" Version="5.54.0" />
     </ItemGroup>

--- a/AzureEnterpriseApplicationOrchestrator/AzureEnterpriseApplicationOrchestrator.csproj
+++ b/AzureEnterpriseApplicationOrchestrator/AzureEnterpriseApplicationOrchestrator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>disable</ImplicitUsings>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
@@ -10,16 +10,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Core" Version="1.38.0" />
-      <PackageReference Include="Azure.Identity" Version="1.10.4" />
-      <PackageReference Include="Azure.ResourceManager" Version="1.10.2" />
-      <PackageReference Include="coverlet.collector" Version="6.0.1">
+      <PackageReference Include="Azure.Core" Version="1.39.0" />
+      <PackageReference Include="Azure.Identity" Version="1.11.3" />
+      <PackageReference Include="Azure.ResourceManager" Version="1.12.0" />
+      <PackageReference Include="coverlet.collector" Version="6.0.2">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
-      <PackageReference Include="Keyfactor.Logging" Version="1.1.1" />
+      <PackageReference Include="Keyfactor.Logging" Version="1.1.2" />
       <PackageReference Include="Keyfactor.Orchestrators.IOrchestratorJobExtensions" Version="0.7.0" />
-      <PackageReference Include="Microsoft.Graph" Version="5.44.0" />
+      <PackageReference Include="Microsoft.Graph" Version="5.54.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 
 - 3.0.0
     - Implement client certificate authentication as a secondary authentication method to Microsoft Graph API
+
+- 3.1.0
+  - fix(deps): Revert main Azure App Registration and Enterprise Application Orchestrator extension .NET project to .NET 6 from .NET 8.


### PR DESCRIPTION
- 3.1.0
  - fix(deps): Revert main Azure App Registration and Enterprise Application Orchestrator extension .NET project to .NET 6 from .NET 8.